### PR TITLE
Refactor: Separate Settings and Add Readme Page

### DIFF
--- a/bookmark-sheets/Code.js
+++ b/bookmark-sheets/Code.js
@@ -1,9 +1,3 @@
-function doGet(e) {
-  return HtmlService.createTemplateFromFile('index')
-      .evaluate()
-      .setTitle('Spreadsheet Viewer');
-}
-
 function include(filename) {
   return HtmlService.createHtmlOutputFromFile(filename)
       .getContent();

--- a/bookmark-sheets/doGet.gs
+++ b/bookmark-sheets/doGet.gs
@@ -1,0 +1,39 @@
+function doGet(e) {
+  let pathInfo = e.pathInfo;
+  let pageToLoad = "index"; // Default page
+
+  if (pathInfo !== undefined && pathInfo !== "" && pathInfo !== "/") {
+    pageToLoad = pathInfo.substring(1); // Remove leading slash
+  }
+
+  let baseUrl = ScriptApp.getService().getUrl();
+  if (baseUrl.endsWith('/')) {
+    baseUrl = baseUrl.slice(0, -1);
+  }
+
+  let template;
+  let title;
+
+  if (pageToLoad === 'index') {
+    template = HtmlService.createTemplateFromFile('index');
+    title = 'Spreadsheet Viewer - Display';
+  } else if (pageToLoad === 'settings') {
+    template = HtmlService.createTemplateFromFile('settings');
+    title = 'Spreadsheet Viewer - Settings';
+  } else if (pageToLoad === 'readme') {
+    template = HtmlService.createTemplateFromFile('readme');
+    title = 'Spreadsheet Viewer - Readme';
+  } else {
+    // Handle unknown paths
+    return HtmlService.createHtmlOutput("Page not found: " + (e.pathInfo ? e.pathInfo : "root"))
+        .setTitle('Error - Page Not Found');
+  }
+
+  template.baseUrl = baseUrl;
+  template.indexUrl = baseUrl; // Explicitly set indexUrl which is same as baseUrl
+  template.settingsUrl = baseUrl + '/settings';
+  template.readmeUrl = baseUrl + '/readme';
+  template.currentPage = pageToLoad; // Pass 'index', 'settings', or 'readme'
+
+  return template.evaluate().setTitle(title);
+}

--- a/bookmark-sheets/index.html
+++ b/bookmark-sheets/index.html
@@ -4,14 +4,17 @@
     <base target="_top">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <?!= include('style'); ?>
+    <?!= include('nav-style'); ?>
   </head>
   <body>
-    <div class="tabs">
-      <button class="tablinks" id="displayTabButton">表示</button>
-      <button class="tablinks" id="settingsTabButton">設定</button>
-    </div>
+    <nav class="common-navigation">
+      <a href="<?= baseUrl ?>" <? if (currentPage === 'index') { ?>class="active"<? } ?>>Display</a>
+      <a href="<?= settingsUrl ?>" <? if (currentPage === 'settings') { ?>class="active"<? } ?>>Settings</a>
+      <a href="<?= readmeUrl ?>" <? if (currentPage === 'readme') { ?>class="active"<? } ?>>Readme</a>
+    </nav>
+    <!-- Tabs div removed -->
 
-    <div id="Display" class="tabcontent">
+    <div id="Display" class="tabcontent" style="display: block;"> <!-- Made visible by default -->
       <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px;">
         <p style="margin: 0;">現在表示中のシート: <span id="currentSheetName">（未選択）</span></p>
         <button id="reloadContentButton" style="padding: 5px 10px; font-size: 0.9em;">&#x21BB; リロード</button> </div>
@@ -20,38 +23,9 @@
       </div>
     </div>
 
-    <div id="Settings" class="tabcontent">
-      <h4>スプレッドシートを検索して選択</h4>
-      <input type="text" id="spreadsheetSearchInput" placeholder="スプレッドシート名を入力">
-      <button id="searchButton">検索</button>
-      <div class="loader" id="searchLoader"></div>
-      <select id="spreadsheetSelector" size="5"></select>
+    <!-- Settings tab content removed -->
 
-      <h4>スプレッドシートIDで選択</h4>
-      <input type="text" id="spreadsheetIdInput" placeholder="スプレッドシートIDを入力">
-      <div id="spreadsheetIdStatus"></div>
-
-      <button id="saveSettingsButton">スプレッドシートを決定</button>
-
-      <hr>
-      <div id="spreadsheetLinkContainerInSettings">
-        </div>
-
-      <hr>
-      <div id="sheetsInfoContainer">
-        </div>
-    </div>
-
-    <div id="confirmationModal" class="modal">
-      <div class="modal-content">
-        <span class="close-button" id="closeModalButton">&times;</span>
-        <h2>設定の確認</h2>
-        <p>以下のスプレッドシートを保存しますか？</p>
-        <p><strong>タイトル:</strong> <span id="confirmedSpreadsheetTitle"></span></p>
-        <button id="confirmSaveButton">はい、保存します</button>
-        <button id="cancelModalButton">キャンセル</button>
-      </div>
-    </div>
+    <!-- Confirmation modal removed -->
 
     <?!= include('script'); ?>
   </body>

--- a/bookmark-sheets/nav-style.css.html
+++ b/bookmark-sheets/nav-style.css.html
@@ -1,0 +1,32 @@
+<style>
+  body {
+    padding-top: 70px; /* Increased padding for nav */
+    margin: 0; /* Ensure body has no default margin that could interfere */
+  }
+  nav.common-navigation {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background-color: #333;
+    padding: 12px 0;
+    text-align: center;
+    z-index: 1000;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    height: 40px; /* Fixed height */
+    line-height: 40px; /* Vertically center links if they are inline-block */
+  }
+  nav.common-navigation a {
+    color: white;
+    margin: 0 20px;
+    text-decoration: none;
+    font-size: 1em; /* Relative font size */
+    padding: 8px 15px;
+    border-radius: 4px;
+    transition: background-color 0.3s;
+  }
+  nav.common-navigation a:hover,
+  nav.common-navigation a.active {
+    background-color: #555;
+  }
+</style>

--- a/bookmark-sheets/readme.html
+++ b/bookmark-sheets/readme.html
@@ -1,151 +1,114 @@
-<!-- Google Apps Script スプレッドシートビューア ウェブアプリ README -->
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+    <base target="_top">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Google Apps Script スプレッドシートビューア ウェブアプリ</title>
+    <title>App Readme/Design</title>
+    <?!= include('nav-style'); ?>
+    <!-- Navigation CSS and common styles might be included here later -->
     <style>
-        body {
-            font-family: Arial, sans-serif;
-            line-height: 1.6;
-            margin: 20px;
-            background-color: #f4f4f4;
-            color: #333;
-        }
-        h1, h2, h3, h4 {
-            color: #0056b3;
-            border-bottom: 2px solid #0056b3;
-            padding-bottom: 5px;
-            margin-top: 25px;
-        }
-        h1 { font-size: 2em; }
-        h2 { font-size: 1.5em; }
-        h3 { font-size: 1.2em; }
-        ul {
-            list-style-type: disc;
-            margin-left: 20px;
-            margin-bottom: 15px;
-        }
-        li {
-            margin-bottom: 5px;
-        }
-        strong {
-            color: #d35400;
-        }
-        .section {
-            background-color: #ffffff;
-            padding: 20px;
-            margin-bottom: 20px;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-        }
-        .code-block {
-            background-color: #e9e9e9;
-            border: 1px solid #ccc;
-            padding: 15px;
-            border-radius: 5px;
-            overflow-x: auto;
-            white-space: pre-wrap;
-            word-wrap: break-word;
-            font-family: 'Courier New', Courier, monospace;
-            font-size: 0.9em;
-        }
-        .note {
-            background-color: #fff3cd;
-            border-left: 5px solid #ffc107;
-            padding: 10px;
-            margin-top: 15px;
-            border-radius: 4px;
-            color: #664d03;
-        }
+        body { font-family: sans-serif; margin: 20px; /* padding-top: 60px; Will be handled by nav-style.css.html */ }
+        h1, h2 { border-bottom: 1px solid #ccc; padding-bottom: 5px; }
+        /* #navigation placeholder styling removed */
+        .code { background-color: #f4f4f4; padding: 2px 5px; border-radius: 3px; font-family: monospace; }
+        table { border-collapse: collapse; margin-top: 1em; }
+        th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
     </style>
 </head>
 <body>
-    <div class="section">
-        <h1>Google Apps Script スプレッドシートビューア ウェブアプリ</h1>
-        <h2>概要</h2>
-        <p>このウェブアプリは、Google Apps Script を使用して構築されており、Google スプレッドシートの内容をウェブページ上で表示するためのツールです。複数のタブ（「表示」と「設定」）を持ち、ユーザーは「設定」タブで表示したいスプレッドシートを選択・決定できます。選ばれたスプレッドシートは「表示」タブにカード形式で視覚的に表示され、タグ、画像、URLなどの情報が含まれます。</p>
-    </div>
+    <nav class="common-navigation">
+      <a href="<?= baseUrl ?>" <? if (currentPage === 'index') { ?>class="active"<? } ?>>Display</a>
+      <a href="<?= settingsUrl ?>" <? if (currentPage === 'settings') { ?>class="active"<? } ?>>Settings</a>
+      <a href="<?= readmeUrl ?>" <? if (currentPage === 'readme') { ?>class="active"<? } ?>>Readme</a>
+    </nav>
 
-    <div class="section">
-        <h2>機能</h2>
-        <h3>1. タブ切り替え</h3>
-        <ul>
-            <li><strong>表示タブ</strong>: 決定されたスプレッドシートのコンテンツが表示されます。</li>
-            <li><strong>設定タブ</strong>: スプレッドシートの選択と設定を行います。</li>
-        </ul>
+    <h1>Spreadsheet Viewer Web App - Design Document</h1>
 
-        <h3>2. スプレッドシートの選択</h3>
-        <p>「設定」タブでは、以下の2つの方法でスプレッドシートを選択できます。</p>
-        <ul>
-            <li><strong>スプレッドシート名を検索して選択</strong>:
-                <ul>
-                    <li>検索ボックスにスプレッドシート名の一部を入力し、「検索」ボタンを押すことで、一致するスプレッドシートのリストが表示されます。</li>
-                    <li>検索中はローディングインジケーターが表示されます。</li>
-                    <li>リストから目的のスプレッドシートを選択できます。</li>
-                </ul>
-            </li>
-            <li><strong>スプレッドシートIDで選択</strong>:
-                <ul>
-                    <li>スプレッドシートのIDを直接入力ボックスに入力できます。</li>
-                    <li>IDの入力が完了すると、自動的にそのスプレッドシートの<strong>タイトル</strong>が取得され、入力欄の下に表示されます。タイトルが取得できない場合はエラーメッセージが表示されます。</li>
-                    <li>検索リストで項目を選択した場合も、そのIDが自動的に入力欄に反映されます。</li>
-                </ul>
-            </li>
-        </ul>
+    <h2>1. Overview</h2>
+    <p>This document describes the structure and design of the Spreadsheet Viewer web application. The application allows users to select a Google Spreadsheet and view its content. Functionality is split across a main display page, a settings page, and this readme page.</p>
 
-        <h3>3. スプレッドシートの決定とシート情報表示</h3>
-        <ul>
-            <li>スプレッドシートが選択された後、「スプレッドシートを決定」ボタンを押すと、そのスプレッドシートの<strong>タイトルを確認</strong>するダイアログが表示されます。</li>
-            <li>ユーザーが確認を承認すると、選択されたスプレッドシートIDが保存され、「設定」タブ内にそのスプレッドシートを新しいタブで開くための<strong>ボタン形式のリンク</strong>が表示されます。</li>
-            <li>決定されたスプレッドシートに含まれる<strong>シートの一覧</strong>も表示されます。各シートには<strong>シート名</strong>、<strong>カラム数</strong>、<strong>行数</strong>、そして<strong>先頭行のカラム名（ヘッダ）一覧</strong>が表示されます。</li>
-        </ul>
+    <h2>2. File Structure</h2>
+    <p>The application consists of the following key files within the 'bookmark-sheets' directory:</p>
+    <table>
+        <thead>
+            <tr>
+                <th>File</th>
+                <th>Purpose</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>index.html</code></td>
+                <td>Main page for displaying spreadsheet content.</td>
+            </tr>
+            <tr>
+                <td><code>settings.html</code></td>
+                <td>Page for configuring application settings, primarily selecting the target spreadsheet.</td>
+            </tr>
+            <tr>
+                <td><code>readme.html</code></td>
+                <td>This design document and application guide.</td>
+            </tr>
+            <tr>
+                <td><code>script.html</code></td>
+                <td>Client-side JavaScript for <code>index.html</code> (content display).</td>
+            </tr>
+            <tr>
+                <td><code>style.html</code></td>
+                <td>CSS styles for <code>index.html</code> and common elements.</td>
+            </tr>
+            <tr>
+                <td><code>settings.js.html</code></td>
+                <td>Client-side JavaScript specific to <code>settings.html</code>.</td>
+            </tr>
+            <tr>
+                <td><code>settings.css.html</code></td>
+                <td>CSS styles specific to <code>settings.html</code>.</td>
+            </tr>
+            <tr>
+                <td><code>doGet.gs</code></td>
+                <td>Server-side Apps Script file containing the main <code>doGet(e)</code> function for routing.</td>
+            </tr>
+            <tr>
+                <td><code>Code.gs</code></td>
+                <td>Server-side Apps Script file for backend logic (e.g., Google Drive interaction, utility functions like <code>include()</code>). Moved from Code.js</td>
+            </tr>
+            <tr>
+                <td><code>appsscript.json</code></td>
+                <td>Apps Script project manifest file.</td>
+            </tr>
+        </tbody>
+    </table>
 
-        <h3>4. コンテンツの表示（「表示」タブ）</h3>
-        <ul>
-            <li>「表示」タブには、決定されたスプレッドシートの最初のシートの内容が表示されます。</li>
-            <li>表示されるコンテンツは、各行がカード形式で表示され、以下のヘッダが存在することを前提としています。
-                <ul>
-                    <li><code>url</code> (必須)</li>
-                    <li><code>title</code> (必須)</li>
-                    <li><code>image</code> (必須)</li>
-                    <li><code>tags</code> (一つ以上、<code>tags</code>で始まるカラム名)</li>
-                </ul>
-            </li>
-            <li>これらの必須ヘッダが存在しない場合、コンテンツは表示されず、必要なヘッダに関するエラーメッセージが表示されます。</li>
-            <li><code>tags</code> カラムは複数存在する場合があり、それらの値は結合されてリスト形式で表示されます。</li>
-            <li>「表示」タブの左上には、現在表示されている<strong>シート名</strong>が表示され、その隣にはシートの内容を<strong>再読み込みするリロードボタン</strong>が配置されています。</li>
-        </ul>
+    <h2>3. Routing</h2>
+    <p>The application uses URL path-based routing, handled by the <code>doGet(e)</code> function in <code>doGet.gs</code>. The <code>e.pathInfo</code> property from the event object determines which page is served:</p>
+    <ul>
+        <li>Base URL (e.g., <code>.../exec/</code>): Serves <code>index.html</code>.</li>
+        <li>Base URL + <code>/settings</code> (e.g., <code>.../exec/settings</code>): Serves <code>settings.html</code>.</li>
+        <li>Base URL + <code>/readme</code> (e.g., <code>.../exec/readme</code>): Serves <code>readme.html</code>.</li>
+    </ul>
+    <p>The <code>HtmlService.createTemplateFromFile(filename).evaluate()</code> method is used to serve these pages.</p>
 
-        <h3>5. その他の機能</h3>
-        <ul>
-            <li><strong>キャッシュ機能</strong>: スプレッドシート名検索の結果はユーザーキャッシュに10分間保存され、同じ検索クエリに対してはキャッシュから素早く結果が返されます。</li>
-            <li><strong>レスポンシブデザイン</strong>: スマートフォンなどのモバイルデバイスでも見やすいように、ビューポート設定と基本的なレスポンシブデザインが適用されています。</li>
-        </ul>
-    </div>
+    <h2>4. Navigation</h2>
+    <p>A common navigation UI is implemented across <code>index.html</code>, <code>settings.html</code>, and <code>readme.html</code>. This allows users to easily switch between the 'Display', 'Settings', and 'Readme' sections of the application. The navigation links will use the appropriate paths (e.g., <code>${webappUrl}</code>, <code>${webappUrl}/settings</code>, <code>${webappUrl}/readme</code>).</p>
 
-    <div class="section">
-        <h2>アプリケーションのデプロイ方法</h2>
-        <ol>
-            <li>Google ドライブで新しい Google スプレッドシートを作成します。</li>
-            <li>「拡張機能」&gt;「Apps Script」を選択し、スクリプトエディタを開きます。</li>
-            <li>提供された <code>Code.gs</code>、<code>index.html</code>、<code>style.html</code>、<code>script.html</code> の内容をそれぞれのファイルにコピー＆ペーストします。</li>
-            <li>Apps Script エディタで、「デプロイ」&gt;「新しいデプロイ」を選択します。</li>
-            <li>「種類の選択」で「ウェブアプリ」を選択します。</li>
-            <li>「アクセス」を「全員」または「Gmail アカウントを持つすべてのユーザー」に設定します（テスト目的の場合）。</li>
-            <li>「デプロイ」をクリックし、必要な承認（権限の許可）を求められたら許可します。</li>
-            <li>デプロイが完了すると、ウェブアプリのURLが発行されます。このURLをブラウザで開いてアプリを使用できます。</li>
-        </ol>
-    </div>
+    <h2>5. Key Functionalities</h2>
+    <h3>5.1. Settings Page (<code>settings.html</code>)</h3>
+    <ul>
+        <li>Search for Google Spreadsheets by name.</li>
+        <li>Select a spreadsheet by its ID.</li>
+        <li>View details of the selected spreadsheet (title, sheet names, headers).</li>
+        <li>Save the selected spreadsheet ID for the application to use.</li>
+    </ul>
+    <h3>5.2. Display Page (<code>index.html</code>)</h3>
+    <ul>
+        <li>Loads and displays content from the first sheet of the currently selected Google Spreadsheet.</li>
+        <li>Content is expected to have specific columns (e.g., 'url', 'title', 'image', 'tags') for optimal display.</li>
+        <li>Provides a reload button to refresh content.</li>
+    </ul>
 
-    <div class="section">
-        <h2>注意事項</h2>
-        <ul>
-            <li>スプレッドシートのコンテンツを表示するには、Apps Script がそのスプレッドシートにアクセスできる必要があります。適切に権限を付与してください。</li>
-            <li>表示タブにコンテンツを表示するためのヘッダ (<code>url</code>, <code>title</code>, <code>image</code>, <code>tags</code> など) が正しく設定されていることを確認してください。</li>
-            <li><code>tags</code> カラムは、<code>tags_jp</code>, <code>tags_en</code> のように <code>tags</code> で始まる複数のカラムがあっても対応します。</li>
-        </ul>
-    </div>
+    <p><em>This readme provides a high-level overview of the application's refactored design.</em></p>
 </body>
 </html>

--- a/bookmark-sheets/script.html
+++ b/bookmark-sheets/script.html
@@ -1,21 +1,5 @@
 <script>
-  let pendingSpreadsheetId = '';
-  let titleFetchTimeout;
-
-  function openTab(tabName, buttonElement) {
-    const tabcontents = document.getElementsByClassName("tabcontent");
-    for (const content of tabcontents) {
-      content.style.display = "none";
-    }
-
-    const tablinks = document.getElementsByClassName("tablinks");
-    for (const link of tablinks) {
-      link.classList.remove("active");
-    }
-
-    document.getElementById(tabName).style.display = "block";
-    buttonElement.classList.add("active");
-  }
+  // openTab function removed
 
   document.addEventListener('DOMContentLoaded', (event) => {
     // 初回ロード時に保存済みのスプレッドシート情報を取得し表示
@@ -23,89 +7,18 @@
       .withSuccessHandler(displaySavedSpreadsheetLink)
       .getSavedSpreadsheetInfo();
 
-    // タブボタンにイベントリスナーを追加
-    const displayTabButton = document.getElementById('displayTabButton');
-    const settingsTabButton = document.getElementById('settingsTabButton');
+    // const displayTabButton = document.getElementById('displayTabButton'); // Removed
     const reloadContentButton = document.getElementById('reloadContentButton'); // リロードボタンを取得
 
-    displayTabButton.addEventListener('click', () => openTab('Display', displayTabButton));
-    settingsTabButton.addEventListener('click', () => {
-      openTab('Settings', settingsTabButton);
-      // 設定タブを開いたときに保存済みのIDを反映
-      google.script.run
-        .withSuccessHandler(function(info) {
-          if (info && info.id) {
-            const idInput = document.getElementById('spreadsheetIdInput');
-            idInput.value = info.id;
-            getTitleForId(info.id); // ID反映後、タイトルも自動取得
-          } else {
-            // 保存済みのIDがない場合はシート情報表示をクリア
-            displaySheetsInfo(null);
-          }
-        })
-        .getSavedSpreadsheetInfo();
-    });
+    // if (displayTabButton) displayTabButton.addEventListener('click', () => openTab('Display', displayTabButton)); // Removed
+    // settingsTabButton listener removed
 
-    // 初期表示はDisplayタブをアクティブにする
-    openTab('Display', displayTabButton);
+    // if (displayTabButton) openTab('Display', displayTabButton); // Removed
 
-    const searchInput = document.getElementById('spreadsheetSearchInput');
-    const searchButton = document.getElementById('searchButton');
-    const idInput = document.getElementById('spreadsheetIdInput');
-    const saveSettingsButton = document.getElementById('saveSettingsButton');
-    const selector = document.getElementById('spreadsheetSelector');
-
-    // 検索ボタンにイベントリスナーを追加
-    searchButton.addEventListener('click', searchSpreadsheets);
-
-    // 検索入力ボックスにイベントリスナーを追加
-    searchInput.addEventListener('keypress', function(e) {
-      if (e.key === 'Enter') {
-        searchSpreadsheets();
-      }
-    });
-
-    // スプレッドシートID入力欄にイベントリスナーを追加
-    idInput.addEventListener('input', function() {
-      if (titleFetchTimeout) {
-        clearTimeout(titleFetchTimeout);
-      }
-      titleFetchTimeout = setTimeout(() => {
-        getTitleForId(idInput.value);
-      }, 500);
-    });
-    idInput.addEventListener('blur', function() {
-      if (titleFetchTimeout) {
-        clearTimeout(titleFetchTimeout);
-      }
-      getTitleForId(idInput.value);
-    });
-    idInput.addEventListener('keypress', function(e) {
-      if (e.key === 'Enter') {
-        if (titleFetchTimeout) {
-          clearTimeout(titleFetchTimeout);
-        }
-        getTitleForId(idInput.value);
-      }
-    });
-
-    // スプレッドシートセレクタのchangeイベントを追加
-    selector.addEventListener('change', function() {
-      const selectedId = this.value;
-      idInput.value = selectedId; // 選択されたIDを入力欄に反映
-      getTitleForId(selectedId); // 反映後、タイトルを自動取得
-    });
-
-    // 「スプレッドシートを決定」ボタンにイベントリスナーを追加
-    saveSettingsButton.addEventListener('click', saveSettings);
-
-    // モーダル関連のボタンにイベントリスナーを追加
-    document.getElementById('closeModalButton').addEventListener('click', closeModal);
-    document.getElementById('confirmSaveButton').addEventListener('click', confirmSave);
-    document.getElementById('cancelModalButton').addEventListener('click', closeModal);
+    // Event listeners for settings elements (searchInput, searchButton, idInput, saveSettingsButton, selector, modal buttons) removed.
 
     // リロードボタンにイベントリスナーを追加
-    reloadContentButton.addEventListener('click', () => {
+    if (reloadContentButton) reloadContentButton.addEventListener('click', () => {
       google.script.run
         .withSuccessHandler(function(info) {
           if (info && info.id) {
@@ -121,221 +34,48 @@
     });
   });
 
-  function searchSpreadsheets() {
-    const query = document.getElementById('spreadsheetSearchInput').value;
-    const loader = document.getElementById('searchLoader');
+  // Functions searchSpreadsheets, populateSpreadsheetSelector, handleSearchError, getTitleForId, saveSettings, showConfirmationModal, confirmSave, closeModal were moved to settings.js.html
 
-    loader.style.display = 'inline-block';
-
-    google.script.run
-      .withSuccessHandler(populateSpreadsheetSelector)
-      .withFailureHandler(handleSearchError)
-      .searchSpreadsheetsByName(query);
-  }
-
-  function populateSpreadsheetSelector(spreadsheets) {
-    const selector = document.getElementById('spreadsheetSelector'); // 修正済み
-    const loader = document.getElementById('searchLoader');
-
-    selector.innerHTML = '';
-    loader.style.display = 'none';
-
-    if (spreadsheets.length === 0) {
-      const option = document.createElement('option');
-      option.value = '';
-      option.textContent = '検索結果なし';
-      selector.appendChild(option);
-      return;
-    }
-    spreadsheets.forEach(ss => {
-      const option = document.createElement('option');
-      option.value = ss.id;
-      option.textContent = ss.name;
-      selector.appendChild(option);
-    });
-  }
-
-  function handleSearchError(error) {
-    const loader = document.getElementById('searchLoader');
-    loader.style.display = 'none';
-    const statusDiv = document.getElementById('spreadsheetIdStatus');
-    statusDiv.textContent = '検索エラー: ' + error.message;
-    statusDiv.className = 'error';
-    console.error('Spreadsheet search error:', error);
-  }
-
-  function getTitleForId(spreadsheetId) {
-    const statusDiv = document.getElementById('spreadsheetIdStatus');
-    statusDiv.textContent = 'タイトルを取得中...';
-    statusDiv.className = '';
-
-    if (!spreadsheetId.trim()) {
-      statusDiv.textContent = '';
-      displaySheetsInfo(null);
-      displayContent({ error: 'スプレッドシートが選択されていません。', sheetName: '（未選択）' });
-      return;
-    }
-
-    google.script.run
-      .withSuccessHandler(function(title) {
-        statusDiv.textContent = 'タイトル: ' + title;
-        statusDiv.className = 'success';
-        google.script.run
-          .withSuccessHandler(displaySheetsInfo)
-          .withFailureHandler(function(error) {
-            displaySheetsInfo(null, 'シート情報の取得に失敗しました: ' + error.message);
-          })
-          .getSpreadsheetSheetsInfo(spreadsheetId);
-
-        loadSheetContent(spreadsheetId);
-
-      })
-      .withFailureHandler(function(error) {
-        statusDiv.textContent = 'エラー: ' + error.message;
-        statusDiv.className = 'error';
-        console.error('Get title error:', error);
-        displaySheetsInfo(null, 'スプレッドシート情報の取得に失敗しました。');
-        displayContent({ error: error.message, sheetName: '（エラー）' });
-      })
-      .getSpreadsheetTitle(spreadsheetId);
-  }
-
-  function saveSettings() {
-    let targetSpreadsheetId = '';
-
-    const selector = document.getElementById('spreadsheetSelector');
-    if (selector.value) {
-      targetSpreadsheetId = selector.value;
-    } else {
-      const idInput = document.getElementById('spreadsheetIdInput').value.trim();
-      if (idInput) {
-        targetSpreadsheetId = idInput;
-      }
-    }
-
-    if (targetSpreadsheetId) {
-      google.script.run
-        .withSuccessHandler(function(title) {
-          pendingSpreadsheetId = targetSpreadsheetId;
-          showConfirmationModal(title);
-        })
-        .withFailureHandler(function(error) {
-          const statusDiv = document.getElementById('spreadsheetIdStatus');
-          statusDiv.textContent = '保存エラー: ' + error.message;
-          statusDiv.className = 'error';
-          console.error('Save settings error (pre-check):', error);
-          displaySheetsInfo(null, '保存前のスプレッドシート情報取得に失敗しました。');
-          displayContent({ error: error.message, sheetName: '（エラー）' });
-        })
-        .getSpreadsheetTitle(targetSpreadsheetId);
-    } else {
-      const statusDiv = document.getElementById('spreadsheetIdStatus');
-      statusDiv.textContent = 'スプレッドシートを選択するか、IDを入力してください。';
-      statusDiv.className = 'error';
-      displaySheetsInfo(null);
-      displayContent({ error: 'スプレッドシートが選択されていません。', sheetName: '（未選択）' });
-    }
-  }
-
-  function showConfirmationModal(title) {
-    document.getElementById('confirmedSpreadsheetTitle').textContent = title;
-    document.getElementById('confirmationModal').style.display = 'block';
-  }
-
-  function confirmSave() {
-    google.script.run
-      .withSuccessHandler((response) => {
-        const statusDiv = document.getElementById('spreadsheetIdStatus');
-        statusDiv.textContent = '設定が保存されました！';
-        statusDiv.className = 'success';
-        closeModal();
-        displaySavedSpreadsheetLink(response); // 保存成功後、リンクとシート情報を表示
-      })
-      .withFailureHandler(function(error) {
-        const statusDiv = document.getElementById('spreadsheetIdStatus');
-        statusDiv.textContent = '保存エラー: ' + error.message;
-        statusDiv.className = 'error';
-        console.error('Save settings error:', error);
-        closeModal();
-        displayContent({ error: error.message, sheetName: '（エラー）' });
-      })
-      .saveSelectedSpreadsheet(pendingSpreadsheetId);
-  }
-
-  function closeModal() {
-    document.getElementById('confirmationModal').style.display = 'none';
-    pendingSpreadsheetId = '';
-  }
-
+  // This version of displaySavedSpreadsheetLink is for index.html (Display Tab)
+  // It updates the currentSheetName and calls loadSheetContent.
+  // It does NOT interact with 'spreadsheetLinkContainerInSettings' or 'sheetsInfoContainer' from settings.html.
   function displaySavedSpreadsheetLink(spreadsheetInfo) {
-    const linkContainer = document.getElementById('spreadsheetLinkContainerInSettings');
-    linkContainer.innerHTML = '';
+    // const linkContainer = document.getElementById('spreadsheetLinkContainerInSettings'); // This element is in settings.html
+    // if (linkContainer) linkContainer.innerHTML = ''; // Not needed for index.html version
+
+    const currentSheetNameElement = document.getElementById('currentSheetName');
 
     if (spreadsheetInfo && spreadsheetInfo.id && spreadsheetInfo.title) {
-      const link = document.createElement('a');
-      link.href = 'https://docs.google.com/spreadsheets/d/' + spreadsheetInfo.id + '/edit';
-      link.textContent = 'スプレッドシートを開く: ' + spreadsheetInfo.title;
-      link.target = '_blank';
-      link.classList.add('open-spreadsheet-button');
-      linkContainer.appendChild(link);
+      // const link = document.createElement('a'); // Link is displayed in settings.html
+      // link.href = 'https://docs.google.com/spreadsheets/d/' + spreadsheetInfo.id + '/edit';
+      // link.textContent = 'スプレッドシートを開く: ' + spreadsheetInfo.title;
+      // link.target = '_blank';
+      // link.classList.add('open-spreadsheet-button');
+      // if (linkContainer) linkContainer.appendChild(link); // Not for index.html
 
-      google.script.run
-        .withSuccessHandler(displaySheetsInfo)
-        .withFailureHandler(function(error) {
-          displaySheetsInfo(null, 'シート情報の取得に失敗しました: ' + error.message);
-        })
-        .getSpreadsheetSheetsInfo(spreadsheetInfo.id);
+      // For index.html, we primarily update the content display, not a link in settings.
+      // The 'currentSheetName' might be updated by displayContent itself later.
+      // displaySheetsInfo is specific to the settings page, so we don't call it here.
+      // google.script.run
+      //   .withSuccessHandler(displaySheetsInfo) // displaySheetsInfo is for settings page
+      //   .withFailureHandler(function(error) {
+      //     displaySheetsInfo(null, 'シート情報の取得に失敗しました: ' + error.message);
+      //   })
+      //   .getSpreadsheetSheetsInfo(spreadsheetInfo.id);
 
       loadSheetContent(spreadsheetInfo.id);
 
     } else {
-      linkContainer.textContent = '現在、スプレッドシートは選択されていません。';
-      displaySheetsInfo(null);
+      // if (linkContainer) linkContainer.textContent = '現在、スプレッドシートは選択されていません。'; // Not for index.html
+      // displaySheetsInfo(null); // displaySheetsInfo is for settings page
+      if(currentSheetNameElement) currentSheetNameElement.textContent = '（未選択）';
       displayContent({ error: 'スプレッドシートが選択されていません。', sheetName: '（未選択）' });
     }
   }
 
-  function displaySheetsInfo(sheetsInfo, errorMessage = null) {
-    const sheetsContainer = document.getElementById('sheetsInfoContainer');
-    sheetsContainer.innerHTML = '';
+  // displaySheetsInfo is now specific to settings.js.html and has been removed from script.html
+  // function displaySheetsInfo(sheetsInfo, errorMessage = null) { ... }
 
-    if (errorMessage) {
-      sheetsContainer.innerHTML = '<p class="error">' + errorMessage + '</p>';
-      return;
-    }
-
-    if (sheetsInfo && sheetsInfo.length > 0) {
-      const title = document.createElement('h4');
-      title.textContent = 'シート一覧:';
-      sheetsContainer.appendChild(title);
-
-      sheetsInfo.forEach(sheet => {
-        const sheetItem = document.createElement('div');
-        sheetItem.classList.add('sheet-item');
-        
-        let headersHtml = '';
-        if (sheet.headers && sheet.headers.length > 0) {
-          const validHeaders = sheet.headers.filter(h => h !== null && h !== undefined && String(h).trim() !== '');
-          if (validHeaders.length > 0) {
-            headersHtml = `<div class="headers">ヘッダ: ${validHeaders.join(', ')}</div>`;
-          } else {
-            headersHtml = `<div class="headers">ヘッダ: (空または認識できるヘッダなし)</div>`;
-          }
-        } else {
-          headersHtml = `<div class="headers">ヘッダ: (なし)</div>`;
-        }
-
-        sheetItem.innerHTML = `
-          <strong>シート名: ${sheet.name}</strong>
-          <span>カラム数: ${sheet.columnCount}, 行数: ${sheet.rowCount}</span>
-          ${headersHtml}
-        `;
-        sheetsContainer.appendChild(sheetItem);
-      });
-    } else {
-      sheetsContainer.textContent = 'このスプレッドシートにはシートがありません、または情報を取得できませんでした。';
-    }
-  }
 
   function loadSheetContent(spreadsheetId) {
     const displayContainer = document.getElementById('displayContentContainer');

--- a/bookmark-sheets/settings.css.html
+++ b/bookmark-sheets/settings.css.html
@@ -1,0 +1,170 @@
+<style>
+  #spreadsheetSearchInput,
+  #spreadsheetIdInput,
+  #spreadsheetSelector {
+    width: calc(100% - 22px);
+    padding: 10px;
+    margin-bottom: 10px;
+    box-sizing: border-box;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 16px;
+  }
+
+  .loader {
+    border: 4px solid #f3f3f3;
+    border-top: 4px solid #3498db;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    animation: spin 1s linear infinite;
+    display: none;
+    vertical-align: middle;
+    margin-left: 10px;
+  }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+
+  .modal {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgba(0,0,0,0.4);
+  }
+
+  .modal-content {
+    background-color: #fefefe;
+    margin: 15% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 90%;
+    max-width: 500px;
+    border-radius: 8px;
+    position: relative;
+    text-align: center;
+    box-sizing: border-box;
+  }
+
+  .close-button {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    position: absolute;
+    right: 10px;
+    top: 5px;
+  }
+
+  .close-button:hover,
+  .close-button:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+  }
+
+  .modal-content button {
+    padding: 10px 20px;
+    margin: 10px;
+    cursor: pointer;
+    border: none;
+    border-radius: 5px;
+    font-size: 16px;
+  }
+
+  .modal-content button:first-of-type {
+    background-color: #4CAF50;
+    color: white;
+  }
+
+  .modal-content button:last-of-type {
+    background-color: #f44336;
+    color: white;
+  }
+
+  #spreadsheetIdStatus {
+    margin-top: 5px;
+    padding: 5px;
+    border-radius: 4px;
+    min-height: 20px;
+    font-size: 0.9em;
+  }
+  #spreadsheetIdStatus.success {
+    background-color: #e6ffe6;
+    color: #006400;
+    border: 1px solid #00c800;
+  }
+  #spreadsheetIdStatus.error {
+    background-color: #ffe6e6;
+    color: #cc0000;
+    border: 1px solid #ff0000;
+  }
+
+  .open-spreadsheet-button {
+    display: block;
+    width: calc(100% - 22px);
+    padding: 10px;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    background-color: #28a745;
+    color: white;
+    text-align: center;
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 16px;
+    box-sizing: border-box;
+    cursor: pointer;
+  }
+
+  .open-spreadsheet-button:hover {
+    background-color: #218838;
+  }
+
+  #sheetsInfoContainer {
+    margin-top: 20px;
+    padding-top: 10px;
+    border-top: 1px solid #eee;
+  }
+
+  .sheet-item {
+    background-color: #f9f9f9;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 10px;
+    margin-bottom: 8px;
+    font-size: 0.95em;
+  }
+
+  .sheet-item strong {
+    color: #333;
+  }
+
+  .sheet-item span {
+    display: block;
+    font-size: 0.85em;
+    color: #666;
+    margin-top: 3px;
+  }
+
+  .sheet-item .headers {
+    font-size: 0.8em;
+    color: #444;
+    margin-top: 5px;
+    word-break: break-all;
+  }
+
+  /* スマートフォン向けの調整 for modal */
+  @media screen and (max-width: 600px) {
+    .modal-content {
+      margin: 10% auto;
+      width: 95%;
+    }
+  }
+</style>

--- a/bookmark-sheets/settings.html
+++ b/bookmark-sheets/settings.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <?!= include('settings.css'); ?>
+    <?!= include('nav-style'); ?>
+  </head>
+  <body>
+    <nav class="common-navigation">
+      <a href="<?= baseUrl ?>" <? if (currentPage === 'index') { ?>class="active"<? } ?>>Display</a>
+      <a href="<?= settingsUrl ?>" <? if (currentPage === 'settings') { ?>class="active"<? } ?>>Settings</a>
+      <a href="<?= readmeUrl ?>" <? if (currentPage === 'readme') { ?>class="active"<? } ?>>Readme</a>
+    </nav>
+    <!-- Navigation UI will be added here later --> <!-- This comment can be removed or kept, it doesn't harm -->
+
+    <div id="Settings" class="tabcontent" style="display: block;"> <!-- Modified to be visible by default -->
+      <h4>スプレッドシートを検索して選択</h4>
+      <input type="text" id="spreadsheetSearchInput" placeholder="スプレッドシート名を入力">
+      <button id="searchButton">検索</button>
+      <div class="loader" id="searchLoader"></div>
+      <select id="spreadsheetSelector" size="5"></select>
+
+      <h4>スプレッドシートIDで選択</h4>
+      <input type="text" id="spreadsheetIdInput" placeholder="スプレッドシートIDを入力">
+      <div id="spreadsheetIdStatus"></div>
+
+      <button id="saveSettingsButton">スプレッドシートを決定</button>
+
+      <hr>
+      <div id="spreadsheetLinkContainerInSettings">
+        </div>
+
+      <hr>
+      <div id="sheetsInfoContainer">
+        </div>
+    </div>
+
+    <div id="confirmationModal" class="modal">
+      <div class="modal-content">
+        <span class="close-button" id="closeModalButton">&times;</span>
+        <h2>設定の確認</h2>
+        <p>以下のスプレッドシートを保存しますか？</p>
+        <p><strong>タイトル:</strong> <span id="confirmedSpreadsheetTitle"></span></p>
+        <button id="confirmSaveButton">はい、保存します</button>
+        <button id="cancelModalButton">キャンセル</button>
+      </div>
+    </div>
+
+    <?!= include('settings.js'); ?>
+  </body>
+</html>

--- a/bookmark-sheets/settings.js.html
+++ b/bookmark-sheets/settings.js.html
@@ -1,0 +1,302 @@
+<script>
+  let pendingSpreadsheetId = '';
+  let titleFetchTimeout;
+
+  // Settings-specific functions
+  function searchSpreadsheets() {
+    const query = document.getElementById('spreadsheetSearchInput').value;
+    const loader = document.getElementById('searchLoader');
+    if (loader) loader.style.display = 'inline-block';
+
+    google.script.run
+      .withSuccessHandler(populateSpreadsheetSelector)
+      .withFailureHandler(handleSearchError)
+      .searchSpreadsheetsByName(query);
+  }
+
+  function populateSpreadsheetSelector(spreadsheets) {
+    const selector = document.getElementById('spreadsheetSelector');
+    const loader = document.getElementById('searchLoader');
+
+    if (selector) selector.innerHTML = '';
+    if (loader) loader.style.display = 'none';
+
+    if (!spreadsheets || spreadsheets.length === 0) {
+      const option = document.createElement('option');
+      option.value = '';
+      option.textContent = '検索結果なし';
+      if (selector) selector.appendChild(option);
+      return;
+    }
+    spreadsheets.forEach(ss => {
+      const option = document.createElement('option');
+      option.value = ss.id;
+      option.textContent = ss.name;
+      if (selector) selector.appendChild(option);
+    });
+  }
+
+  function handleSearchError(error) {
+    const loader = document.getElementById('searchLoader');
+    if (loader) loader.style.display = 'none';
+    const statusDiv = document.getElementById('spreadsheetIdStatus');
+    if (statusDiv) {
+        statusDiv.textContent = '検索エラー: ' + error.message;
+        statusDiv.className = 'error';
+    }
+    console.error('Spreadsheet search error:', error);
+  }
+
+  function getTitleForId(spreadsheetId) {
+    const statusDiv = document.getElementById('spreadsheetIdStatus');
+    if (!statusDiv) return;
+
+    statusDiv.textContent = 'タイトルを取得中...';
+    statusDiv.className = '';
+
+    if (!spreadsheetId || !spreadsheetId.trim()) {
+      statusDiv.textContent = '';
+      displaySheetsInfo(null); // Clear sheet info if ID is empty
+      // DO NOT CALL displayContent or loadSheetContent here
+      return;
+    }
+
+    google.script.run
+      .withSuccessHandler(function(title) {
+        statusDiv.textContent = 'タイトル: ' + title;
+        statusDiv.className = 'success';
+        // Fetch and display sheet details in settings page
+        google.script.run
+          .withSuccessHandler(displaySheetsInfo)
+          .withFailureHandler(function(error) {
+            displaySheetsInfo(null, 'シート情報の取得に失敗しました: ' + error.message);
+          })
+          .getSpreadsheetSheetsInfo(spreadsheetId);
+        // DO NOT CALL loadSheetContent here
+      })
+      .withFailureHandler(function(error) {
+        statusDiv.textContent = 'エラー: ' + error.message;
+        statusDiv.className = 'error';
+        console.error('Get title error:', error);
+        displaySheetsInfo(null, 'スプレッドシート情報の取得に失敗しました。');
+        // DO NOT CALL displayContent here
+      })
+      .getSpreadsheetTitle(spreadsheetId);
+  }
+
+  function saveSettings() {
+    let targetSpreadsheetId = '';
+    const selector = document.getElementById('spreadsheetSelector');
+    const idInput = document.getElementById('spreadsheetIdInput');
+
+    if (selector && selector.value) {
+      targetSpreadsheetId = selector.value;
+    } else if (idInput && idInput.value.trim()) {
+      targetSpreadsheetId = idInput.value.trim();
+    }
+
+    const statusDiv = document.getElementById('spreadsheetIdStatus');
+
+    if (targetSpreadsheetId) {
+      google.script.run
+        .withSuccessHandler(function(title) {
+          pendingSpreadsheetId = targetSpreadsheetId;
+          showConfirmationModal(title);
+        })
+        .withFailureHandler(function(error) {
+          if (statusDiv) {
+            statusDiv.textContent = '保存エラー: ' + error.message;
+            statusDiv.className = 'error';
+          }
+          console.error('Save settings error (pre-check):', error);
+          displaySheetsInfo(null, '保存前のスプレッドシート情報取得に失敗しました。');
+          // DO NOT CALL displayContent here
+        })
+        .getSpreadsheetTitle(targetSpreadsheetId);
+    } else {
+      if (statusDiv) {
+        statusDiv.textContent = 'スプレッドシートを選択するか、IDを入力してください。';
+        statusDiv.className = 'error';
+      }
+      displaySheetsInfo(null); // Clear sheet info
+      // DO NOT CALL displayContent here
+    }
+  }
+
+  function showConfirmationModal(title) {
+    const modalTitle = document.getElementById('confirmedSpreadsheetTitle');
+    const modal = document.getElementById('confirmationModal');
+    if (modalTitle) modalTitle.textContent = title;
+    if (modal) modal.style.display = 'block';
+  }
+
+  function confirmSave() {
+    const statusDiv = document.getElementById('spreadsheetIdStatus');
+    google.script.run
+      .withSuccessHandler((response) => {
+        if (statusDiv) {
+            statusDiv.textContent = '設定が保存されました！';
+            statusDiv.className = 'success';
+        }
+        closeModal();
+        // Call the settings-specific version of displaySavedSpreadsheetLink
+        displaySavedSpreadsheetLink(response);
+      })
+      .withFailureHandler(function(error) {
+        if (statusDiv) {
+            statusDiv.textContent = '保存エラー: ' + error.message;
+            statusDiv.className = 'error';
+        }
+        console.error('Save settings error:', error);
+        closeModal();
+        // DO NOT CALL displayContent here
+      })
+      .saveSelectedSpreadsheet(pendingSpreadsheetId);
+  }
+
+  function closeModal() {
+    const modal = document.getElementById('confirmationModal');
+    if (modal) modal.style.display = 'none';
+    pendingSpreadsheetId = '';
+  }
+
+  // Settings-specific version of displaySavedSpreadsheetLink
+  // This updates UI elements within settings.html ONLY
+  function displaySavedSpreadsheetLink(spreadsheetInfo) {
+    const linkContainer = document.getElementById('spreadsheetLinkContainerInSettings');
+    if (!linkContainer) return;
+    linkContainer.innerHTML = '';
+
+    if (spreadsheetInfo && spreadsheetInfo.id && spreadsheetInfo.title) {
+      const link = document.createElement('a');
+      link.href = 'https://docs.google.com/spreadsheets/d/' + spreadsheetInfo.id + '/edit';
+      link.textContent = 'スプレッドシートを開く: ' + spreadsheetInfo.title;
+      link.target = '_blank';
+      link.classList.add('open-spreadsheet-button');
+      linkContainer.appendChild(link);
+
+      // Fetch and display sheet details in settings page
+      google.script.run
+        .withSuccessHandler(displaySheetsInfo)
+        .withFailureHandler(function(error) {
+          displaySheetsInfo(null, 'シート情報の取得に失敗しました: ' + error.message);
+        })
+        .getSpreadsheetSheetsInfo(spreadsheetInfo.id);
+      // DO NOT CALL loadSheetContent or displayContent here
+    } else {
+      linkContainer.textContent = '現在、スプレッドシートは選択されていません。';
+      displaySheetsInfo(null); // Clear sheet info
+      // DO NOT CALL loadSheetContent or displayContent here
+    }
+  }
+
+  function displaySheetsInfo(sheetsInfo, errorMessage = null) {
+    const sheetsContainer = document.getElementById('sheetsInfoContainer');
+    if (!sheetsContainer) return;
+    sheetsContainer.innerHTML = '';
+
+    if (errorMessage) {
+      sheetsContainer.innerHTML = '<p class="error">' + errorMessage + '</p>';
+      return;
+    }
+
+    if (sheetsInfo && sheetsInfo.length > 0) {
+      const title = document.createElement('h4');
+      title.textContent = 'シート一覧:';
+      sheetsContainer.appendChild(title);
+
+      sheetsInfo.forEach(sheet => {
+        const sheetItem = document.createElement('div');
+        sheetItem.classList.add('sheet-item');
+
+        let headersHtml = '';
+        if (sheet.headers && sheet.headers.length > 0) {
+          const validHeaders = sheet.headers.filter(h => h !== null && h !== undefined && String(h).trim() !== '');
+          if (validHeaders.length > 0) {
+            headersHtml = `<div class="headers">ヘッダ: ${validHeaders.join(', ')}</div>`;
+          } else {
+            headersHtml = `<div class="headers">ヘッダ: (空または認識できるヘッダなし)</div>`;
+          }
+        } else {
+          headersHtml = `<div class="headers">ヘッダ: (なし)</div>`;
+        }
+
+        sheetItem.innerHTML = `
+          <strong>シート名: ${sheet.name}</strong>
+          <span>カラム数: ${sheet.columnCount}, 行数: ${sheet.rowCount}</span>
+          ${headersHtml}
+        `;
+        sheetsContainer.appendChild(sheetItem);
+      });
+    } else {
+      sheetsContainer.textContent = 'このスプレッドシートにはシートがありません、または情報を取得できませんでした。';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', (event) => {
+    // Initial load of saved spreadsheet info for settings page
+    google.script.run
+      .withSuccessHandler(function(info) {
+        displaySavedSpreadsheetLink(info); // Updates link and sheet info in settings
+        if (info && info.id) {
+          const idInput = document.getElementById('spreadsheetIdInput');
+          if (idInput) idInput.value = info.id;
+          // getTitleForId also updates the statusDiv and sheet info, which is good for settings page
+          getTitleForId(info.id);
+        } else {
+           displaySheetsInfo(null); // Clear sheet info if nothing is saved
+        }
+      })
+      .withFailureHandler(function(error) {
+        console.error("Error loading saved spreadsheet info on settings page:", error);
+        const statusDiv = document.getElementById('spreadsheetIdStatus');
+        if (statusDiv) {
+            statusDiv.textContent = '保存された情報の取得エラー: ' + error.message;
+            statusDiv.className = 'error';
+        }
+        displaySheetsInfo(null); // Clear sheet info on error
+      })
+      .getSavedSpreadsheetInfo();
+
+    // Event listeners for settings page elements
+    const searchInput = document.getElementById('spreadsheetSearchInput');
+    const searchButton = document.getElementById('searchButton');
+    const idInput = document.getElementById('spreadsheetIdInput');
+    const saveSettingsButton = document.getElementById('saveSettingsButton');
+    const selector = document.getElementById('spreadsheetSelector');
+
+    if (searchButton) searchButton.addEventListener('click', searchSpreadsheets);
+    if (searchInput) searchInput.addEventListener('keypress', function(e) { if (e.key === 'Enter') searchSpreadsheets(); });
+
+    if (idInput) {
+        idInput.addEventListener('input', function() {
+            if (titleFetchTimeout) clearTimeout(titleFetchTimeout);
+            titleFetchTimeout = setTimeout(() => { getTitleForId(idInput.value); }, 500);
+        });
+        idInput.addEventListener('blur', function() {
+            if (titleFetchTimeout) clearTimeout(titleFetchTimeout);
+            getTitleForId(idInput.value);
+        });
+        idInput.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                if (titleFetchTimeout) clearTimeout(titleFetchTimeout);
+                getTitleForId(idInput.value);
+            }
+        });
+    }
+    if (selector) selector.addEventListener('change', function() {
+        const selectedId = this.value;
+        if (idInput) idInput.value = selectedId;
+        getTitleForId(selectedId);
+    });
+    if (saveSettingsButton) saveSettingsButton.addEventListener('click', saveSettings);
+
+    const closeModalButton = document.getElementById('closeModalButton');
+    const confirmSaveButton = document.getElementById('confirmSaveButton');
+    const cancelModalButton = document.getElementById('cancelModalButton');
+
+    if(closeModalButton) closeModalButton.addEventListener('click', closeModal);
+    if(confirmSaveButton) confirmSaveButton.addEventListener('click', confirmSave);
+    if(cancelModalButton) cancelModalButton.addEventListener('click', closeModal);
+  });
+</script>

--- a/bookmark-sheets/style.html
+++ b/bookmark-sheets/style.html
@@ -34,18 +34,6 @@
     border-top: none;
   }
 
-  #spreadsheetSearchInput,
-  #spreadsheetIdInput,
-  #spreadsheetSelector {
-    width: calc(100% - 22px);
-    padding: 10px;
-    margin-bottom: 10px;
-    box-sizing: border-box;
-    border: 1px solid #ccc;
-    border-radius: 4px;
-    font-size: 16px;
-  }
-
   button {
     padding: 10px 15px;
     margin-top: 10px;
@@ -61,156 +49,11 @@
     opacity: 0.9;
   }
 
-  .loader {
-    border: 4px solid #f3f3f3;
-    border-top: 4px solid #3498db;
-    border-radius: 50%;
-    width: 20px;
-    height: 20px;
-    animation: spin 1s linear infinite;
-    display: none;
-    vertical-align: middle;
-    margin-left: 10px;
-  }
-
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-  }
-
-  .modal {
-    display: none;
-    position: fixed;
-    z-index: 1;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.4);
-  }
-
-  .modal-content {
-    background-color: #fefefe;
-    margin: 15% auto;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 90%;
-    max-width: 500px;
-    border-radius: 8px;
-    position: relative;
-    text-align: center;
-    box-sizing: border-box;
-  }
-
-  .close-button {
-    color: #aaa;
-    float: right;
-    font-size: 28px;
-    font-weight: bold;
-    position: absolute;
-    right: 10px;
-    top: 5px;
-  }
-
-  .close-button:hover,
-  .close-button:focus {
-    color: black;
-    text-decoration: none;
-    cursor: pointer;
-  }
-
-  .modal-content button {
-    padding: 10px 20px;
-    margin: 10px;
-    cursor: pointer;
-    border: none;
-    border-radius: 5px;
-    font-size: 16px;
-  }
-
-  .modal-content button:first-of-type {
-    background-color: #4CAF50;
-    color: white;
-  }
-
-  .modal-content button:last-of-type {
-    background-color: #f44336;
-    color: white;
-  }
-
-  #spreadsheetIdStatus {
-    margin-top: 5px;
-    padding: 5px;
-    border-radius: 4px;
-    min-height: 20px;
-    font-size: 0.9em;
-  }
-  #spreadsheetIdStatus.success {
-    background-color: #e6ffe6;
-    color: #006400;
-    border: 1px solid #00c800;
-  }
-  #spreadsheetIdStatus.error {
-    background-color: #ffe6e6;
-    color: #cc0000;
-    border: 1px solid #ff0000;
-  }
-
-  /* スプレッドシートを開くリンク（ボタン風）のスタイル */
-  .open-spreadsheet-button {
-    display: block;
-    width: calc(100% - 22px);
-    padding: 10px;
-    margin-top: 20px;
-    margin-bottom: 10px;
-    background-color: #28a745;
-    color: white;
-    text-align: center;
-    text-decoration: none;
-    border-radius: 4px;
-    font-size: 16px;
-    box-sizing: border-box;
-    cursor: pointer;
-  }
-
-  .open-spreadsheet-button:hover {
-    background-color: #218838;
-  }
-
-  /* シート情報コンテナのスタイル */
-  #sheetsInfoContainer {
-    margin-top: 20px;
-    padding-top: 10px;
-    border-top: 1px solid #eee;
-  }
-
-  .sheet-item {
-    background-color: #f9f9f9;
-    border: 1px solid #ddd;
-    border-radius: 4px;
-    padding: 10px;
-    margin-bottom: 8px;
-    font-size: 0.95em;
-  }
-
-  .sheet-item strong {
-    color: #333;
-  }
-
-  .sheet-item span {
-    display: block;
-    font-size: 0.85em;
-    color: #666;
-    margin-top: 3px;
-  }
-
-  .sheet-item .headers {
-    font-size: 0.8em;
-    color: #444;
-    margin-top: 5px;
-    word-break: break-all;
-  }
+  /* Styles for #spreadsheetSearchInput, #spreadsheetIdInput, #spreadsheetSelector,
+     .loader, @keyframes spin, .modal, .modal-content, .close-button,
+     .modal-content button, #spreadsheetIdStatus, .open-spreadsheet-button,
+     #sheetsInfoContainer, .sheet-item and its children
+     have been moved to settings.css.html */
 
   /* 表示タブのコンテンツスタイル */
   .content-item {
@@ -280,9 +123,6 @@
     .tabcontent {
       padding: 10px;
     }
-    .modal-content {
-      margin: 10% auto;
-      width: 95%;
-    }
+    /* .modal-content media query part moved to settings.css.html */
   }
 </style>


### PR DESCRIPTION
This commit refactors the Google Apps Script project to introduce a multi-page architecture and separates the settings functionality into its own dedicated page.

Key changes include:

-   **Settings Page (`settings.html`):**
    -   Created `settings.html` to house all UI and functionality related to spreadsheet selection and configuration.
    -   Moved relevant HTML from `index.html` to `settings.html`.
    -   Created `settings.js.html` containing JavaScript specific to the settings page, refactored from the original `script.html`.
    -   Created `settings.css.html` with CSS styles specific to the settings page, extracted from `style.html`.

-   **Routing (`doGet.gs`):**
    -   Created `doGet.gs` to handle server-side routing.
    -   The `doGet(e)` function now serves `index.html`, `settings.html`, or `readme.html` based on `e.pathInfo` (`/`, `/settings`, `/readme`).

-   **Readme Page (`readme.html`):**
    -   The content of `readme.html` has been replaced with a design document detailing the new application structure, routing, and file organization.

-   **Navigation:**
    -   Implemented a common navigation bar across all pages (`index.html`, `settings.html`, `readme.html`) allowing you to switch between Display, Settings, and Readme sections.
    -   Navigation URLs are generated in `doGet.gs` and passed to the templates.
    -   Created `nav-style.css.html` for common navigation styling.

-   **`index.html` Refactoring:**
    -   Simplified `index.html` to solely focus on displaying spreadsheet content, removing the previous tabbed interface.
    -   `script.html` (for `index.html`) has been cleaned of settings-related code.

-   **Code Organization:**
    -   Server-side logic in `Code.gs` remains for core spreadsheet interactions and the `include()` utility.

This restructuring enhances maintainability, separates concerns, and provides a clearer user experience with distinct pages for different functionalities.